### PR TITLE
fixes modal, removes async functions

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -5,7 +5,7 @@ import styles from "./page.module.scss"
 import Image from "next/image"
 import { SignInBtn } from "../components/auth/AuthButtons";
 
-export default async function Page() {
+export default function Page() {
 
   return (
     <>

--- a/app/portal/chapters/page.js
+++ b/app/portal/chapters/page.js
@@ -1,8 +1,8 @@
 "use client"
 
-import React from "react"
+import React, { useState } from "react"
 import styles from "./page.module.scss"
-import { Button, IconButton } from "@mui/material"
+import Button from "@mui/material/Button"
 import AddIcon from "@mui/icons-material/Add"
 import { DataGrid } from "@mui/x-data-grid"
 import Modal from "@/components/Modal/Modal"
@@ -47,8 +47,8 @@ const rows = [
   },
 ]
 
-export default async function Page() {
-  const [open, setOpen] = React.useState(false)
+export default function Page() {
+  const [open, setOpen] = useState(false)
   const handleOpen = () => setOpen(true)
   const handleClose = () => setOpen(false)
 
@@ -59,19 +59,10 @@ export default async function Page() {
         <div className="header-row">
           <h1>Chapters</h1>
           <div className="add-button">
-            <IconButton
-              color="primary"
-              size="large"
-              onClick={handleOpen}
-              aria-label="add"
-              className="compact-button"
-            >
-              <AddIcon />
-            </IconButton>
             <Button
               variant="contained"
               startIcon={<AddIcon />}
-              onClick={handleOpen}
+              onClick={() => handleOpen()}
               aria-label="add"
               className="full-button"
             >

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -4,7 +4,7 @@ import styles from "./page.module.scss"
 import { Button, IconButton } from "@mui/material"
 import AddIcon from "@mui/icons-material/Add"
 
-export default async function Page() {
+export default function Page() {
   return (
     <main className={styles.courses}>
       <section className="container">

--- a/app/portal/members/page.js
+++ b/app/portal/members/page.js
@@ -4,7 +4,7 @@ import styles from "./page.module.scss"
 import { Button, IconButton } from "@mui/material"
 import AddIcon from "@mui/icons-material/Add"
 
-export default async function Page() {
+export default function Page() {
   return (
     <main className={styles.main}>
       <section className="container">

--- a/app/portal/page.js
+++ b/app/portal/page.js
@@ -3,7 +3,7 @@ import SectionAdmin from "./SectionAdmin"
 import SectionCourses from "./SectionCourses"
 import SectionWelcome from "./SectionWelcome"
 
-export default async function Page() {
+export default function Page() {
 
   return (
     // This is the landing page for users that are logged in


### PR DESCRIPTION
This PR fixes issue #15 , referencing a broken modal on the `portal/chapters` page. As it turns out, you can't use async functions in client components in NextJS without running into issues like this. In this case, `useState` can actually cause infinite re-renders, causing your tab to crash when you attempt to change state in some way.