### PR TITLE
patch/authRedirect

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,11 +1,23 @@
 "use client"
 
+import { useEffect } from 'react'
 import { Button, Link } from "@mui/material"
 import styles from "./page.module.scss"
 import Image from "next/image"
-import { SignInBtn } from "../components/auth/AuthButtons";
+import { SignInBtn } from "../components/auth/AuthButtons"
+import { useSession } from "next-auth/react"
+import { redirect } from 'next/navigation'
 
 export default function Page() {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session) {
+      redirect('/portal');
+    }
+  
+  }, [session])
+  
 
   return (
     <>


### PR DESCRIPTION
This PR adds a quick redirect that checks if the current user is authenticated and, if so, pushes them to `/portal`. This handles the edge case for users signing in, leaving the site, returning while their session is still active, and not being able to get to the `/portal` dashboard. It also ensures that in all circumstances users get pushed where they need to be once they do authenticate.

This resolves issue #13.