### PR TITLE
feature/user-roles

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -5,17 +5,29 @@ const authOptions = {
   secret: process.env.NEXTAUTH_SECRET,
   providers: [
     Auth0Provider({
+      profile: function profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.nickname,
+          email: profile.email,
+          image: profile.picture,
+          roles: profile.userRoles
+        };
+      },
       clientId: process.env.AUTH0_CLIENT_ID,
       clientSecret: process.env.AUTH0_CLIENT_SECRET,
       issuer: process.env.AUTH0_ISSUER_BASE_URL
     })
   ],
   callbacks: {
-    jwt: async function jwt({ token, account }) {
+    jwt: async function jwt({ token, account, user }) {
       if(account) {
         token.accessToken = account.access_token;
         token.idToken = account.id_token;
         token.id = token.sub;
+      }
+      if (user) {
+        token.roles = user.roles;
       }
 
       return token;
@@ -24,6 +36,7 @@ const authOptions = {
       session.accessToken = token.accessToken;
       session.idToken = token.idToken;
       session.user.id = token.id;
+      session.roles = token.roles;
 
       return session;
     }

--- a/app/page.js
+++ b/app/page.js
@@ -38,6 +38,7 @@ export default function Page() {
               src="/images/Code-Your-Dreams-Hero.jpg"
               fill
               style={{ objectFit: "cover" }}
+              alt="Code Your Dreams students cheering"
             />
           </div>
           <div className={styles["hero-message"]}>


### PR DESCRIPTION
This PR adds some logic to the `[...nextauth]` config file that pulls any given user's roles from Auth0, storing it in the JWT provided through Auth0 + `next-auth` as well as in the `next-auth` session post-login.

Something worth noting: we'll want to document the process within the Auth0 dashboard regarding setting it up to pass roles back to the app, as Auth0 doesn't do it by default just because you create user roles. It's pretty straightforward, just needing to code up a quick action to be run during the login process, but worth noting for handoff nonetheless.