### PR TITLE
Feature/courses role based rendering

### DIFF
--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -15,13 +15,12 @@ import useCheckTokenExpired from "@/utils/useCheckTokenExpired"
 import { useData } from "@/context/appContext"
 
 const handleRowClick = (params) => {
-  // TODO: we'll want to add a descriptive ID like a URL slug instead of an "id" string
-  const { id } = params.row
+  const { id, name } = params.row
 
   return (
     <Link
       underline="hover"
-      href={`/portal/courses/${id}`}
+      href={`/portal/courses/${name.toLowerCase().replace(" ", "-")}`}
       aria-label={`Open detail page for the ${params.value} course`}
     >
       {params.value}
@@ -147,8 +146,6 @@ export default function Page() {
 
         <div className={styles.table}>
           <div className={styles["table-container"]}>
-            {/* TODO: Clicking on a course name should open up a detail page */}
-            {/* TODO: Hide the "chapters" and "visibility" columns from non-CYD users. */}
             <div className="data-grid">
               {localCourses && (
                 <DataGrid

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -166,9 +166,12 @@ export default function Page() {
         </div>
 
         {/* TODO: Show only to non-CYD users */}
-        <p className="italic">
-          Contact Code Your Dreams for access to more courses.
-        </p>
+        {
+          current_user && current_user.role_id === 3 && 
+          <p className="italic">
+            Contact Code Your Dreams for access to more courses.
+          </p>
+        }
       </section>
 
       <Modal title="Create a New Course" open={open} handleClose={handleClose}>

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -98,6 +98,16 @@ export default function Page() {
     }
   })
 
+  const columnVisibility = (column) => {
+    if (current_user.chapter_id !== 1 && column.field === "chapters") {
+      return
+    }
+    if (current_user.chapter_id !== 1 && column.field === "visibility") {
+      return
+    }
+    return column
+  }
+
   useEffect(() => {
     console.log(courses)
     if (courses) {
@@ -144,7 +154,7 @@ export default function Page() {
                 <DataGrid
                   rows={localCourses}
                   getRowId={(row) => row.id}
-                  columns={columns}
+                  columns={columns.filter(columnVisibility)}
                   initialState={{
                     pagination: {
                       paginationModel: { page: 0, pageSize: 20 },
@@ -162,7 +172,6 @@ export default function Page() {
           </div>
         </div>
 
-        {/* TODO: Show only to non-CYD users */}
         {
           current_user && current_user.role_id === 3 && 
           <p className="italic">


### PR DESCRIPTION
This pull request implements several changes on the Courses page - most notably in regard to dynamically rendering elements based on the currently signed-in user's information.

### Changes made:

- The bottom-most message calling users to request CYD for access to more courses is now hidden for CYD users
- The "visibility" and "Chapters" columns are now hidden for non-CYD users
- Clicking on a course name now opens a detail page with a unique, descriptive URL "slug" (ex: "App Inventor" becomes `portal/courses/app-inventor`)