### PR TITLE
feature/courses-permissions-materials-columns

### DIFF
--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -54,14 +54,14 @@ const columns = [
     flex: 2,
   },
   {
-    field: "files",
+    field: "materialsCount",
     headerName: "Materials",
     headerAlign: "right",
     type: "number",
     width: 150,
   },
   {
-    field: "chapters",
+    field: "permissionsCount",
     headerName: "Chapters",
     headerAlign: "right",
     type: "number",


### PR DESCRIPTION
This PR completes the BE work which added accurate counts for associated chapters and course materials per course displayed.

![image](https://github.com/BloomTech-Labs/code-your-dreams-fe/assets/55460082/4ece2a95-1185-4ef3-8330-bb494566659f)

(NOTE: These counts are currently the same for both existing courses in our DB - this is accurate, as our seeds are set up that way.)