### PR TITLE
updated header and underlined data table links

### DIFF
--- a/app/portal/chapters/page.js
+++ b/app/portal/chapters/page.js
@@ -35,7 +35,7 @@ export default function Page() {
 
     return (
       <Link
-        underline="hover"
+        underline="always"
         href={`/portal/chapters/${id}`}
         aria-label={`Open chapter detail page for ${params.value}`}
       >

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -100,7 +100,7 @@ export default function Page() {
     const { url, materialName } = params.row
 
     return (
-      <Link underline="hover" href={`${url}`} target="_new">
+      <Link underline="always" href={`${url}`} target="_new">
         {materialName}
       </Link>
     )

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -18,7 +18,7 @@ const handleRowClick = (params) => {
 
   return (
     <Link
-      underline="hover"
+      underline="always"
       href={`/portal/courses/${name.toLowerCase().replace(" ", "-")}`}
       aria-label={`Open detail page for the ${params.value} course`}
     >

--- a/components/layout/Header/Header.jsx
+++ b/components/layout/Header/Header.jsx
@@ -8,15 +8,25 @@ import { useData } from "@/context/appContext"
 
 export default function Header() {
   const { current_user } = useData()
+
+  const roleMap = {
+    super_admin: "Super Admin",
+    admin: "Admin",
+    user: "Staff",
+  }
+
   return (
     <header className={styles["site-header"]}>
       <div className={`container ${styles["header-container"]}`}>
         <div className={styles["left-side"]}>
           <SiteLogo />
-          <div className="h4">
-            {current_user && current_user.role === "admin" && `${current_user.chapter_name} - ${current_user.role[0].toUpperCase() + current_user.role.slice(1)}`}
-            {current_user && current_user.role === "super_admin" && `${current_user.chapter_name} - Super Admin`}
-            {current_user && current_user.role === "user" && `${current_user.chapter_name} - Staff`}
+          <div className={styles["org-header"]}>
+            <span className={`${styles.title} h4`}>
+              {current_user ? current_user.chapter_name : ""}
+            </span>
+            <span className={styles.role}>
+              {current_user ? roleMap[current_user.role] : ""}
+            </span>
           </div>
         </div>
         <nav>

--- a/components/layout/Header/Header.module.scss
+++ b/components/layout/Header/Header.module.scss
@@ -24,14 +24,30 @@ header.site-header {
     flex-wrap: nowrap;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
 
     .left-side {
       display: flex;
       flex-direction: row;
       flex-wrap: nowrap;
-      justify-content: flex-start;
       align-items: center;
       gap: 1rem;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      .org-header {
+        display: flex;
+        flex-direction: column;
+
+        line-height: 1.2;
+        .title { font-weight: 500; }
+        .role {
+          padding-left: 0.5rem;
+          font-weight: 200;
+          font-style: italic;
+        }
+      }
     }
 
     nav {


### PR DESCRIPTION
This PR turned into to core changes:

1. Tidied up the page header to de-emphasize the role compared to the org name and to better handle narrower screen widths.
2. Made inline DataGrid links always underlined to make it explicitly clear that there are links to click on—this should be particularly helpful for accessibility, especially color blindness.
