### PR TITLE
Feature/add new course

### DIFF
--- a/app/portal/courses/_components/NewCourse.jsx
+++ b/app/portal/courses/_components/NewCourse.jsx
@@ -1,8 +1,15 @@
 "use client"
 
-import { TextField } from "@mui/material"
+import { TextField, FormControlLabel, Checkbox } from "@mui/material"
 
-export default function NewCourse() {
+export default function NewCourse({ formState, setFormState, onSubmit }) {
+  const handleChange = (e) => {
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    setFormState({
+      ...formState,
+      [e.target.name]: value,
+    })
+  }
   return (
     <>
       {/* TODO: Take in prop for which table to add a new instance. */}
@@ -16,12 +23,29 @@ export default function NewCourse() {
         label="Course Name"
         variant="outlined"
         helperText="The course name to be displayed in the app"
+        name="name"
+        value={formState.name}
+        onChange={handleChange}
       />
       <TextField
         required
         id="course-description"
         label="Description"
         helperText="A short description about the course"
+        name="description"
+        value={formState.description}
+        onChange={handleChange}
+      />
+      <FormControlLabel
+        label="Publish?"
+        control={
+          <Checkbox
+            name="visibility"
+            color="primary"
+            checked={formState.visibility || false}
+            onChange={handleChange}
+          />
+        }
       />
     </>
   )

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -76,11 +76,26 @@ const columns = [
   },
 ]
 
+const initialState = {
+  name: '',
+  description: '',
+  visibility: false
+}
+
 export default function Page() {
   const [localCourses, setLocalCourses] = useState(null)
   const [open, setOpen] = useState(false)
+  const [formState, setFormState] = useState(initialState)
   const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  const handleClose = () => {
+    setOpen(false)
+    setFormState(initialState)
+  }
+  const handleSubmitForm = (data) => {
+    console.log('Form data submitted:', formState);
+    setFormState(initialState)
+    setOpen(false);
+  }
 
   useCheckTokenExpired()
   const { courses, current_user } = useData()
@@ -176,8 +191,12 @@ export default function Page() {
         )}
       </section>
 
-      <Modal title="Create a New Course" open={open} handleClose={handleClose}>
-        <NewCourse />
+      <Modal title="Create a New Course" open={open} handleClose={handleClose} handleSubmit={handleSubmitForm}>
+        <NewCourse
+          formState={formState}
+          setFormState={setFormState}
+          onSubmit={handleSubmitForm}
+        />
       </Modal>
     </main>
   )

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -12,6 +12,7 @@ import VisibilityIcon from "@mui/icons-material/Visibility"
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff"
 import useCheckTokenExpired from "@/utils/useCheckTokenExpired"
 import { useData } from "@/context/appContext"
+import AxiosWithAuth from "@/utils/axiosWithAuth"
 
 const handleRowClick = (params) => {
   const { name } = params.row
@@ -86,15 +87,23 @@ export default function Page() {
   const [localCourses, setLocalCourses] = useState(null)
   const [open, setOpen] = useState(false)
   const [formState, setFormState] = useState(initialState)
+  const axiosInstance = AxiosWithAuth()
   const handleOpen = () => setOpen(true)
   const handleClose = () => {
     setOpen(false)
     setFormState(initialState)
   }
-  const handleSubmitForm = (data) => {
-    console.log('Form data submitted:', formState);
-    setFormState(initialState)
-    setOpen(false);
+  const handleSubmitForm = () => {
+    axiosInstance.post(`${process.env.NEXT_PUBLIC_BE_API_URL}/courses/create`, formState)
+    .then((res) => {
+      console.log('Form data submitted to database:', res.data)
+      setLocalCourses([...localCourses, res.data[0]])
+      setFormState(initialState)
+      setOpen(false)
+    })
+    .catch((err) => {
+      console.error(err)
+    })
   }
 
   useCheckTokenExpired()

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -4,7 +4,7 @@ import { Button, IconButton, Box, Modal as MuiModal } from "@mui/material"
 import CloseIcon from "@mui/icons-material/Close"
 import styles from "./Modal.module.scss"
 
-const Modal = ({ children, title, open, handleClose }) => {
+const Modal = ({ children, title, open, handleSubmit, handleClose }) => {
   return (
     <MuiModal
       open={open}
@@ -27,7 +27,7 @@ const Modal = ({ children, title, open, handleClose }) => {
           <div className={styles["modal-footer"]}>
             <Button
               variant="contained"
-              onClick={handleClose}
+              onClick={handleSubmit}
               aria-label="Save changes"
             >
               Save


### PR DESCRIPTION
This pull request updates the Courses page to enable the submitting of new courses. By handling `formState` and the necessary `handleSubmit` functionality in the Course page's `page.jsx`, we're able to pass them down to their separate places - the `NewCourse.jsx` text inputs as well as the `Modal.jsx` "Save" button.

Additional changes have been made so that when a new course is submitted, the Data Grid updates with that new course's data - minus the counts for associated chapters or course materials, which show on refresh currently.