### PR TITLE
79 portal does not load cleanly with only the footer visible on screen

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,11 +1,11 @@
 import "../styles/globals.scss"
 import { Roboto_Flex } from "next/font/google"
-import Footer from "components/layout/Footer/Footer"
 import { NextAuthProvider } from "./providers"
 import { AppProvider } from "@/context/appContext"
-import Header from "@/components/layout/Header/Header"
 import { Suspense } from "react"
 import Loading from "./loading"
+import Header from "@/components/layout/Header/Header"
+import Footer from "@/components/layout/Footer/Footer"
 
 const robotoflex = Roboto_Flex({ subsets: ["latin"] })
 

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,6 +3,9 @@ import { Roboto_Flex } from "next/font/google"
 import Footer from "components/layout/Footer/Footer"
 import { NextAuthProvider } from "./providers"
 import { AppProvider } from "@/context/appContext"
+import Header from "@/components/layout/Header/Header"
+import { Suspense } from "react"
+import Loading from "./loading"
 
 const robotoflex = Roboto_Flex({ subsets: ["latin"] })
 
@@ -19,12 +22,15 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={robotoflex.className}>
-        <NextAuthProvider>
-          <AppProvider>
-            {children}
-          </AppProvider>
-        </NextAuthProvider>
-        <Footer />
+        <Suspense fallback={<Loading />}>
+          <NextAuthProvider>
+            <AppProvider>
+              <Header />
+              {children}
+              <Footer />
+            </AppProvider>
+          </NextAuthProvider>
+        </Suspense>
       </body>
     </html>
   )

--- a/app/loading.js
+++ b/app/loading.js
@@ -1,0 +1,5 @@
+import LoadingBlock from "@/components/layout/LoadingBlock/LoadingBlock"
+
+export default function Loading() {
+  return <LoadingBlock />
+}

--- a/app/page.js
+++ b/app/page.js
@@ -11,15 +11,6 @@ export default function Page() {
 
   return (
     <>
-      <header className={styles.header}>
-        <Image
-          priority
-          src="/images/CYD-Logo.png"
-          width={112}
-          height={64}
-          alt="A laptop with Code Your Dreams on the screen"
-        />
-      </header>
       <main className={styles.main}>
         <section className={styles.hero}>
           <div className={styles["image-wrapper"]}>

--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -1,18 +1,6 @@
 @import "styles/variables";
 @import "styles/media";
 
-.header {
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  background-color: transparent;
-  position: relative;
-
-  box-shadow: none;
-  -webkit-box-shadow: none;
-  -moz-box-shadow: none;
-}
-
 .main {
   background-color: $cyd-light-gray;
 

--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -14,11 +14,6 @@
 }
 
 .main {
-  margin-top: calc(-1 * $header-height);
-  @include desktop-xl {
-    margin-top: calc(-1 * $header-height-xl);
-  }
-  
   background-color: $cyd-light-gray;
 
   .hero {

--- a/app/portal/layout.js
+++ b/app/portal/layout.js
@@ -1,12 +1,14 @@
-import Header from "@/components/layout/Header/Header"
 import Navigation from "@/components/layout/Navigation/Navigation"
+import { Suspense } from "react"
+import Loading from "./loading"
 
 export default function PortalLayout({ children }) {
   return (
     <>
-      <Header />
-      <Navigation />
-      {children}
+      <Suspense fallback={<Loading />}>
+        <Navigation />
+        {children}
+      </Suspense>
     </>
   )
 }

--- a/app/portal/loading.js
+++ b/app/portal/loading.js
@@ -1,0 +1,5 @@
+import LoadingBlock from "@/components/layout/LoadingBlock/LoadingBlock"
+
+export default function Loading() {
+  return <LoadingBlock />
+}

--- a/app/portal/page.js
+++ b/app/portal/page.js
@@ -3,6 +3,7 @@
 import { useEffect } from "react"
 import { useSession } from "next-auth/react"
 import { redirect } from "next/navigation"
+import LoadingBlock from "@/components/layout/LoadingBlock/LoadingBlock"
 
 export default function Page() {
   const { data: session } = useSession()
@@ -15,5 +16,5 @@ export default function Page() {
     }
   }, [session])
 
-  return <main>Loading...</main>
+  return <LoadingBlock />
 }

--- a/components/layout/Header/Header.jsx
+++ b/components/layout/Header/Header.jsx
@@ -2,9 +2,8 @@
 
 import SiteLogo from "../SiteLogo/SiteLogo"
 import styles from "./Header.module.scss"
-import { Button, IconButton } from "@mui/material"
-import PersonIcon from "@mui/icons-material/Person"
 import { useData } from "@/context/appContext"
+import NavBar from "./NavBar"
 
 export default function Header() {
   const { current_user } = useData()
@@ -29,28 +28,7 @@ export default function Header() {
             </span>
           </div>
         </div>
-        <nav>
-          <IconButton
-            href="/portal/account"
-            color="primary"
-            size="large"
-            aria-label="View account"
-            className="compact-button"
-            tabIndex={5}
-          >
-            <PersonIcon />
-          </IconButton>
-          <Button
-            href="/portal/account"
-            variant="text"
-            endIcon={<PersonIcon />}
-            aria-label="View account"
-            className="full-button"
-            tabIndex={5}
-          >
-            Account
-          </Button>
-        </nav>
+        {current_user ? <NavBar /> : ""}
       </div>
     </header>
   )

--- a/components/layout/Header/Header.module.scss
+++ b/components/layout/Header/Header.module.scss
@@ -49,13 +49,6 @@ header.site-header {
         }
       }
     }
-
-    // nav {
-    //   display: flex;
-    //   flex-direction: row;
-    //   align-items: center;
-    //   gap: 1rem;
-    // }
   }
 }
 

--- a/components/layout/Header/Header.module.scss
+++ b/components/layout/Header/Header.module.scss
@@ -50,11 +50,18 @@ header.site-header {
       }
     }
 
-    nav {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 1rem;
-    }
+    // nav {
+    //   display: flex;
+    //   flex-direction: row;
+    //   align-items: center;
+    //   gap: 1rem;
+    // }
   }
+}
+
+nav.navbar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
 }

--- a/components/layout/Header/NavBar.jsx
+++ b/components/layout/Header/NavBar.jsx
@@ -1,0 +1,32 @@
+"use client"
+
+import styles from "./Header.module.scss"
+import { Button, IconButton } from "@mui/material"
+import PersonIcon from "@mui/icons-material/Person"
+
+export default function NavBar() {
+  return (
+    <nav className={styles.navbar}>
+      <IconButton
+        href="/portal/account"
+        color="primary"
+        size="large"
+        aria-label="View account"
+        className="compact-button"
+        tabIndex={5}
+      >
+        <PersonIcon />
+      </IconButton>
+      <Button
+        href="/portal/account"
+        variant="text"
+        endIcon={<PersonIcon />}
+        aria-label="View account"
+        className="full-button"
+        tabIndex={5}
+      >
+        Account
+      </Button>
+    </nav>
+  )
+}

--- a/components/layout/LoadingBlock/LoadingBlock.jsx
+++ b/components/layout/LoadingBlock/LoadingBlock.jsx
@@ -1,0 +1,9 @@
+import styles from "./LoadingBlock.module.scss"
+
+export default function LoadingBlock() {
+  return (
+    <main className={styles.temp}>
+      <span>Loading...</span>
+    </main>
+  )
+}

--- a/components/layout/LoadingBlock/LoadingBlock.module.scss
+++ b/components/layout/LoadingBlock/LoadingBlock.module.scss
@@ -1,0 +1,7 @@
+.temp {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  span { font-style: italic; }
+}


### PR DESCRIPTION
Cleaned up how page redirects look as the app loads. Put the global header at the top of the app, including on the landing page (including logic to keep user links and data out of view). It's not perfect, but an improvement.