### PR TITLE
Feature/course details page

### DIFF
--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -38,16 +38,16 @@ const showEditButton = () => {
 const columns = [
   { field: "id", headerName: "ID", width: 100 },
   {
-    field: "url",
+    field: "material_link",
     headerName: "Link",
     headerAlign: "center",
     align: "center",
     width: 100,
     renderCell: (params) => showLinkButton(params.value),
   },
-  { field: "materialName", headerName: "Name", width: 250 },
-  { field: "materialType", headerName: "Type", width: 150 },
-  { field: "materialDetails", headerName: "Details", width: 450 },
+  { field: "name", headerName: "Name", width: 250 },
+  { field: "material_type", headerName: "Type", width: 150 },
+  { field: "description", headerName: "Details", width: 450 },
   {
     field: "edit",
     headerName: "Edit",
@@ -123,20 +123,19 @@ export default function Page() {
           } else if (selectedMaterials === null) {
             setSelectedMaterials([obj])
           } else if (selectedMaterials) {
-            setSelectedMaterials([...selectedMaterials, obj])
+            setSelectedMaterials([obj, ...selectedMaterials])
           }
         }
       })
     }
-    console.log(selectedMaterials)
   })
 
   const handleRowClick = (params) => {
-    const { url, materialName } = params.row
+    const { url, name } = params.row
 
     return (
       <Link underline="always" href={`${url}`} target="_new">
-        {materialName}
+        {name}
       </Link>
     )
   }
@@ -150,7 +149,6 @@ export default function Page() {
         {selectedCourse && <Typography color="text.primary">{selectedCourse.name}</Typography>}
       </BreadcrumbRow>
 
-      {/* TODO: Display only when course is hidden */}
       {
         selectedCourse && selectedCourse.visibility === false ?
           <Alert
@@ -183,7 +181,6 @@ export default function Page() {
             <EditIcon fontSize="inherit" />
           </IconButton>
         </div>
-        {/* TODO: Fill in this field from the database. */}
         <p>
           {
             selectedCourse && selectedCourse.description
@@ -203,26 +200,29 @@ export default function Page() {
           </IconButton>
         </div>
         <div className="data-grid">
-          <DataGrid
-            rows={rows}
-            columns={columns.map((column) =>
-              column.field === "materialName"
-                ? { ...column, renderCell: handleRowClick }
-                : column
-            )}
-            initialState={{
-              pagination: {
-                paginationModel: { pageSize: 20 },
-              },
-            }}
-            pageSizeOptions={[20]}
-            slots={{
-              noRowsOverlay: NoRowsOverlay,
-            }}
-            autoHeight={true}
-            sx={{ "--DataGrid-overlayHeight": "300px" }}
-            aria-label="Data grid of course materials"
-          />
+          {
+            selectedMaterials && 
+              <DataGrid
+                rows={selectedMaterials}
+                columns={columns.map((column) =>
+                  column.field === "name"
+                    ? { ...column, renderCell: handleRowClick }
+                    : column
+                )}
+                initialState={{
+                  pagination: {
+                    paginationModel: { pageSize: 20 },
+                  },
+                }}
+                pageSizeOptions={[20]}
+                slots={{
+                  noRowsOverlay: NoRowsOverlay,
+                }}
+                autoHeight={true}
+                sx={{ "--DataGrid-overlayHeight": "300px" }}
+                aria-label="Data grid of course materials"
+              />
+          }
         </div>
       </section>
 

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -95,27 +95,40 @@ export default function Page() {
   const handleCloseCourse = () => setOpenCourse(false)
   // Material NEW modal
   const [openMaterialNew, setOpenMaterialNew] = useState(false)
+  // Selected Course Data
   const [selectedCourse, setSelectedCourse] = useState(null)
+  const [selectedMaterials, setSelectedMaterials] = useState(null)
   const handleOpenMaterialNew = () => setOpenMaterialNew(true)
   const handleCloseMaterialNew = () => setOpenMaterialNew(false)
-  const { courses } = useData();
+  const { courses, course_materials } = useData();
 
   const pathname = usePathname()
   const regex = /-/g
   const newStr = pathname.slice(16).replace(regex, " ")
 
-  console.log(newStr)
 
   useEffect(() => {
-    console.log(courses)
     if (courses) {
       courses.some((obj) => {
-        console.log(obj.name.toLowerCase() === newStr)
         if (obj.name.toLowerCase() === newStr) {
           setSelectedCourse(obj)
         }
       })
     }
+    if (course_materials) {
+      course_materials.some((obj) => {
+        if (selectedCourse && obj.course_id === selectedCourse.id) {
+          if (selectedMaterials && selectedMaterials.includes(obj)) {
+            return
+          } else if (selectedMaterials === null) {
+            setSelectedMaterials([obj])
+          } else if (selectedMaterials) {
+            setSelectedMaterials([...selectedMaterials, obj])
+          }
+        }
+      })
+    }
+    console.log(selectedMaterials)
   })
 
   const handleRowClick = (params) => {

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -138,23 +138,28 @@ export default function Page() {
       </BreadcrumbRow>
 
       {/* TODO: Display only when course is hidden */}
-      <Alert
-        iconMapping={{
-          warning: <VisibilityOffIcon fontSize="inherit" />,
-        }}
-        severity="warning"
-        className="container"
-      >
-        This course is hidden.{" "}
-        <a onClick={() => handleOpenCourse()} className={styles.alert}>
-          Edit the course settings
-        </a>{" "}
-        to make it visible.
-      </Alert>
+      {
+        selectedCourse && selectedCourse.visibility === false ?
+          <Alert
+            iconMapping={{
+              warning: <VisibilityOffIcon fontSize="inherit" />,
+            }}
+            severity="warning"
+            className="container"
+          >
+            This course is hidden.{" "}
+            <a onClick={() => handleOpenCourse()} className={styles.alert}>
+              Edit the course settings
+            </a>{" "}
+            to make it visible.
+          </Alert>
+          :
+          null
+      }
 
       <section className="container">
         <div className="header-row">
-          <h1>Course Name</h1>
+          <h1>{selectedCourse && selectedCourse.name}</h1>
           {/* TODO: This button should only be visible to super admin users */}
           <IconButton
             color="primary"
@@ -168,7 +173,7 @@ export default function Page() {
         {/* TODO: Fill in this field from the database. */}
         <p>
           {
-            "{This is a course description that is provided in the courses table.}"
+            selectedCourse && selectedCourse.description
           }
         </p>
       </section>

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { Alert, IconButton, Link, Typography } from "@mui/material"
 import AddIcon from "@mui/icons-material/Add"
 import EditIcon from "@mui/icons-material/Edit"
@@ -15,6 +15,8 @@ import NewMaterial from "../_components/NewMaterial"
 import EditMaterial from "../_components/EditMaterial"
 import EditButton from "@/components/admin/EditButton/EditButton"
 import styles from "./page.module.scss"
+import { usePathname } from 'next/navigation'
+import { useData } from "@/context/appContext"
 
 const showLinkButton = (url) => {
   return (
@@ -93,8 +95,28 @@ export default function Page() {
   const handleCloseCourse = () => setOpenCourse(false)
   // Material NEW modal
   const [openMaterialNew, setOpenMaterialNew] = useState(false)
+  const [selectedCourse, setSelectedCourse] = useState(null)
   const handleOpenMaterialNew = () => setOpenMaterialNew(true)
   const handleCloseMaterialNew = () => setOpenMaterialNew(false)
+  const { courses } = useData();
+
+  const pathname = usePathname()
+  const regex = /-/g
+  const newStr = pathname.slice(16).replace(regex, " ")
+
+  console.log(newStr)
+
+  useEffect(() => {
+    console.log(courses)
+    if (courses) {
+      courses.some((obj) => {
+        console.log(obj.name.toLowerCase() === newStr)
+        if (obj.name.toLowerCase() === newStr) {
+          setSelectedCourse(obj)
+        }
+      })
+    }
+  })
 
   const handleRowClick = (params) => {
     const { url, materialName } = params.row
@@ -112,8 +134,7 @@ export default function Page() {
         <Link underline="hover" color="inherit" href="/portal/courses">
           Courses
         </Link>
-        {/* TODO: Insert course name from database for current page */}
-        <Typography color="text.primary">{"{course_name}"}</Typography>
+        {selectedCourse && <Typography color="text.primary">{selectedCourse.name}</Typography>}
       </BreadcrumbRow>
 
       {/* TODO: Display only when course is hidden */}

--- a/app/portal/courses/page.js
+++ b/app/portal/courses/page.js
@@ -16,11 +16,12 @@ import AxiosWithAuth from "@/utils/axiosWithAuth"
 
 const handleRowClick = (params) => {
   const { name } = params.row
+  const regex = /( |%20)/g;
 
   return (
     <Link
       underline="always"
-      href={`/portal/courses/${name.toLowerCase().replace(" ", "-")}`}
+      href={`/portal/courses/${name.toLowerCase().replace(regex, "-")}`}
       aria-label={`Open detail page for the ${params.value} course`}
     >
       {params.value}


### PR DESCRIPTION
This pull request continues the work on the "Courses" section of the app, specifically the "Course details" page.

Course details now reads the unique URL "slug" for each course. We then use it to compare against the course's currently in our database/context on the FE, ensuring we're always rendering the correct course details based on user selection.

It also now uses the currently selected course's `id` to pull that course's materials from the database/context, rendering them in the data grid appropriately.