### PR TITLE
Feature/edit course

### DIFF
--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -78,7 +78,7 @@ export default function Page() {
   const [formState, setFormState] = useState(initialState)
   const handleOpenMaterialNew = () => setOpenMaterialNew(true)
   const handleCloseMaterialNew = () => setOpenMaterialNew(false)
-  const { courses, course_materials } = useData();
+  const { courses, course_materials, setCourses } = useData();
   const axiosInstance = AxiosWithAuth()
   const [editCourseDetails, setEditCourseDetails] = useState(null);
   const router = useRouter()
@@ -137,6 +137,13 @@ export default function Page() {
    .then((res) => {
     setOpenCourse(false)
     setEditCourseDetails(null)
+    setCourses(courses.map((i) => {
+      if (i.id === editCourseData.id) {
+        return editCourseData
+      } else {
+        return i
+      }
+    }))
     router.push('/portal/courses')
    })
    .catch((err) => {

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -139,7 +139,7 @@ export default function Page() {
     setEditCourseDetails(null)
     setCourses(courses.map((i) => {
       if (i.id === editCourseData.id) {
-        return editCourseData
+        return editCourseDetails
       } else {
         return i
       }

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -80,6 +80,7 @@ export default function Page() {
   const handleCloseMaterialNew = () => setOpenMaterialNew(false)
   const { courses, course_materials } = useData();
   const axiosInstance = AxiosWithAuth()
+  const [editCourseDetails, setEditCourseDetails] = useState(null);
 
   const pathname = usePathname()
   const regex = /-/g
@@ -119,6 +120,10 @@ export default function Page() {
       .catch((err) => {
         console.log(err)
       })
+  }
+
+  const handleSubmitEditCourse = () => {
+    console.log(editCourseDetails)
   }
 
   const handleSubmitForm = () => {
@@ -186,7 +191,7 @@ export default function Page() {
         }
       })
     }
-  }, [])
+  }, [courses, course_materials, selectedMaterials, selectedCourse])
 
   const handleRowClick = (params) => {
     const { material_link, name } = params.row
@@ -281,10 +286,12 @@ export default function Page() {
         title="Edit Course"
         open={openCourse}
         handleClose={handleCloseCourse}
+        handleSubmit={handleSubmitEditCourse}
       >
         <EditCourse 
           selectedCourse={selectedCourse}
-          setSelectedCourse={setSelectedCourse}
+          editCourseDetails={editCourseDetails}
+          setEditCourseDetails={setEditCourseDetails}
         />
       </Modal>
       <Modal

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -15,7 +15,7 @@ import NewMaterial from "../_components/NewMaterial"
 import EditMaterial from "../_components/EditMaterial"
 import EditButton from "@/components/admin/EditButton/EditButton"
 import styles from "./page.module.scss"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { useData } from "@/context/appContext"
 import AxiosWithAuth from "@/utils/axiosWithAuth"
 
@@ -81,6 +81,7 @@ export default function Page() {
   const { courses, course_materials } = useData();
   const axiosInstance = AxiosWithAuth()
   const [editCourseDetails, setEditCourseDetails] = useState(null);
+  const router = useRouter()
 
   const pathname = usePathname()
   const regex = /-/g
@@ -136,6 +137,7 @@ export default function Page() {
    .then((res) => {
     setOpenCourse(false)
     setEditCourseDetails(null)
+    router.push('/portal/courses')
    })
    .catch((err) => {
     console.log(err)
@@ -189,7 +191,7 @@ export default function Page() {
   useEffect(() => {
     if (courses) {
       courses.some((obj) => {
-        if (obj.name.toLowerCase() === newStr) {
+        if (obj.name.toLowerCase().replace(/-/g, " ") === newStr) {
           setSelectedCourse(obj)
         }
       })

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -282,7 +282,7 @@ export default function Page() {
         open={openCourse}
         handleClose={handleCloseCourse}
       >
-        <EditCourse />
+        <EditCourse selectedCourse={selectedCourse} />
       </Modal>
       <Modal
         title="Add Material"

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -186,7 +186,7 @@ export default function Page() {
         }
       })
     }
-  })
+  }, [])
 
   const handleRowClick = (params) => {
     const { material_link, name } = params.row
@@ -282,7 +282,10 @@ export default function Page() {
         open={openCourse}
         handleClose={handleCloseCourse}
       >
-        <EditCourse selectedCourse={selectedCourse} />
+        <EditCourse 
+          selectedCourse={selectedCourse}
+          setSelectedCourse={setSelectedCourse}
+        />
       </Modal>
       <Modal
         title="Add Material"

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -123,7 +123,23 @@ export default function Page() {
   }
 
   const handleSubmitEditCourse = () => {
-    console.log(editCourseDetails)
+    /*
+      1. When form submitted, send user back to /courses
+    */
+   const editCourseData = {
+    id: editCourseDetails.id,
+    name: editCourseDetails.name,
+    description: editCourseDetails.description,
+    visibility: editCourseDetails.visibility
+   }
+   axiosInstance.post(`${process.env.NEXT_PUBLIC_BE_API_URL}/courses/update/${selectedCourse.id}`, editCourseData)
+   .then((res) => {
+    setOpenCourse(false)
+    setEditCourseDetails(null)
+   })
+   .catch((err) => {
+    console.log(err)
+   })
   }
 
   const handleSubmitForm = () => {

--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -12,13 +12,20 @@ import {
 import DeleteForeverIcon from "@mui/icons-material/DeleteForeverOutlined"
 import DestroyButton from "@/components/admin/DestroyButton/DestroyButton"
 
-export default function EditCourse({ selectedCourse }) {
-  console.log(selectedCourse)
+export default function EditCourse({ selectedCourse, setSelectedCourse }) {
+  const handleChange = (e) => {
+    const value =
+      e.target.type === "checkbox" ? e.target.checked : e.target.value
+      console.log(value)
+      setSelectedCourse({
+      ...selectedCourse,
+      [e.target.name]: value,
+    })
+  }
   return (
     <>
       {/* TODO: Take in prop for database entry to be edited.
       Link form to update that project when saved. */}
-      {/* TODO: Fill in all details in form from DB. */}
       <TextField
         required
         id="course-name"
@@ -26,6 +33,8 @@ export default function EditCourse({ selectedCourse }) {
         variant="outlined"
         inputlabelprops={{ shrink: true }}
         value={selectedCourse.name}
+        name="name"
+        onChange={handleChange}
       />
       <TextField
         required
@@ -33,9 +42,10 @@ export default function EditCourse({ selectedCourse }) {
         label="Description"
         inputlabelprops={{ shrink: true }}
         value={selectedCourse.description}
+        name="description"
+        onChange={handleChange}
       />
       <Card variant="outlined" className="modal-card">
-        {/* TODO: Connect the checkbox to the form and select checked/not-checked based on course data */}
         <FormControlLabel
           label="Published"
           control={
@@ -43,7 +53,7 @@ export default function EditCourse({ selectedCourse }) {
               name="visibility"
               color="primary"
               checked={selectedCourse.visibility}
-              onChange=""
+              onChange={handleChange}
             />
           }
         />

--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -21,14 +21,12 @@ export default function EditCourse({ selectedCourse, editCourseDetails, setEditC
   */
   useEffect(() => {
     if (editCourseDetails === null) {
-      console.log('useEffect/setEditCourseDetails run')
       setEditCourseDetails(selectedCourse)
     }
   }, [])
 
   const handleChange = (e) => {
     const value = e.target.type === "checkbox" ? e.target.checked : e.target.value
-      console.log(value)
       setEditCourseDetails({
       ...editCourseDetails,
       [e.target.name]: value,

--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from 'react';
 import {
   Card,
   Checkbox,
@@ -12,13 +13,24 @@ import {
 import DeleteForeverIcon from "@mui/icons-material/DeleteForeverOutlined"
 import DestroyButton from "@/components/admin/DestroyButton/DestroyButton"
 
-export default function EditCourse({ selectedCourse, setSelectedCourse }) {
+export default function EditCourse({ selectedCourse, editCourseDetails, setEditCourseDetails }) {
+  /*
+    When we edit a course's name, it may mess with the ability to actually render the course's info on the details page.
+    Options: 
+    When a course's new info is submitted, also adjust the course's object in Context & then change the URL. Ideally, the page will refresh, seek the new URL stub in Context, and display the course's new information.
+  */
+  useEffect(() => {
+    if (editCourseDetails === null) {
+      console.log('useEffect/setEditCourseDetails run')
+      setEditCourseDetails(selectedCourse)
+    }
+  }, [])
+
   const handleChange = (e) => {
-    const value =
-      e.target.type === "checkbox" ? e.target.checked : e.target.value
+    const value = e.target.type === "checkbox" ? e.target.checked : e.target.value
       console.log(value)
-      setSelectedCourse({
-      ...selectedCourse,
+      setEditCourseDetails({
+      ...editCourseDetails,
       [e.target.name]: value,
     })
   }
@@ -26,37 +38,43 @@ export default function EditCourse({ selectedCourse, setSelectedCourse }) {
     <>
       {/* TODO: Take in prop for database entry to be edited.
       Link form to update that project when saved. */}
-      <TextField
-        required
-        id="course-name"
-        label="Course Name"
-        variant="outlined"
-        inputlabelprops={{ shrink: true }}
-        value={selectedCourse.name}
-        name="name"
-        onChange={handleChange}
-      />
-      <TextField
-        required
-        id="course-description"
-        label="Description"
-        inputlabelprops={{ shrink: true }}
-        value={selectedCourse.description}
-        name="description"
-        onChange={handleChange}
-      />
-      <Card variant="outlined" className="modal-card">
-        <FormControlLabel
-          label="Published"
-          control={
-            <Checkbox
-              name="visibility"
-              color="primary"
-              checked={selectedCourse.visibility}
-              onChange={handleChange}
-            />
-          }
+      {editCourseDetails &&
+        <TextField
+          required
+          id="course-name"
+          label="Course Name"
+          variant="outlined"
+          inputlabelprops={{ shrink: true }}
+          value={editCourseDetails.name}
+          name="name"
+          onChange={handleChange}
         />
+      }
+      {editCourseDetails &&
+        <TextField
+          required
+          id="course-description"
+          label="Description"
+          inputlabelprops={{ shrink: true }}
+          value={editCourseDetails.description}
+          name="description"
+          onChange={handleChange}
+        />
+      }
+      <Card variant="outlined" className="modal-card">
+        {editCourseDetails && 
+          <FormControlLabel
+            label="Published"
+            control={
+              <Checkbox
+                name="visibility"
+                color="primary"
+                checked={editCourseDetails.visibility}
+                onChange={handleChange}
+              />
+            }
+          />
+        }
         <FormHelperText>
           If unselected, the course is in draft and not visible to users.
         </FormHelperText>

--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -12,7 +12,8 @@ import {
 import DeleteForeverIcon from "@mui/icons-material/DeleteForeverOutlined"
 import DestroyButton from "@/components/admin/DestroyButton/DestroyButton"
 
-export default function EditCourse() {
+export default function EditCourse({ selectedCourse }) {
+  console.log(selectedCourse)
   return (
     <>
       {/* TODO: Take in prop for database entry to be edited.
@@ -23,8 +24,16 @@ export default function EditCourse() {
         id="course-name"
         label="Course Name"
         variant="outlined"
+        inputlabelprops={{ shrink: true }}
+        value={selectedCourse.name}
       />
-      <TextField required id="course-description" label="Description" />
+      <TextField
+        required
+        id="course-description"
+        label="Description"
+        inputlabelprops={{ shrink: true }}
+        value={selectedCourse.description}
+      />
       <Card variant="outlined" className="modal-card">
         {/* TODO: Connect the checkbox to the form and select checked/not-checked based on course data */}
         <FormControlLabel
@@ -33,7 +42,7 @@ export default function EditCourse() {
             <Checkbox
               name="visibility"
               color="primary"
-              checked=""
+              checked={selectedCourse.visibility}
               onChange=""
             />
           }

--- a/context/appContext.jsx
+++ b/context/appContext.jsx
@@ -111,7 +111,8 @@ export const AppProvider = ({ children }) => {
         courses,
         course_materials,
         material_types,
-        course_permissions
+        course_permissions,
+        setCourses
     }}>
       {children}
     </AppContext.Provider>


### PR DESCRIPTION
This pull request enables the "Edit Course" feature found on the "Course Details" page.

Changes made:

- "Edit Course" form now tracked by local state from `courses/[id]`, allowing us to edit the selected course details separately from the details being rendered on base page
- Edited course data now sent in an `axios` request from `courses/[id]` when form submitted
- "Edit Course" form/modal closes and user is routed back to `/courses` on submission - this allows the courses page to show the results of the user's form submission
- `setCourses` is now exposed from Context to the entire app to use where needed
- Using `setCourses`, the edited course is replaced with the updated version when user submits the "Edit Course" form
- Found a bug where courses that include hyphens in their name can't be retrieved and displayed on the "Course Details" page because that hyphen remains when comparing to `newStr`, the value used to check the unique URL and pull that course's data. This is fixed by updating the check to also remove hyphens, enabling accurate comparison