### PR TITLE
Feature/delete-courses-materials

### DIFF
--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -20,6 +20,7 @@ export default function EditCourse({ selectedCourse, editCourseDetails, setEditC
     When a course's new info is submitted, also adjust the course's object in Context & then change the URL. Ideally, the page will refresh, seek the new URL stub in Context, and display the course's new information.
   */
   useEffect(() => {
+    console.log(selectedCourse)
     if (editCourseDetails === null) {
       setEditCourseDetails(selectedCourse)
     }
@@ -91,7 +92,7 @@ export default function EditCourse({ selectedCourse, editCourseDetails, setEditC
         </p>
         {/* TODO: This button should be disabled if there are >0 materials
           linked to the chapter. */}
-        <DestroyButton action="delete" isFullButton={true}>
+        <DestroyButton action="delete" isFullButton={true} selectedCourse={selectedCourse}>
           <DeleteForeverIcon />
         </DestroyButton>
       </Card>

--- a/app/portal/courses/_components/EditCourse.jsx
+++ b/app/portal/courses/_components/EditCourse.jsx
@@ -20,7 +20,6 @@ export default function EditCourse({ selectedCourse, editCourseDetails, setEditC
     When a course's new info is submitted, also adjust the course's object in Context & then change the URL. Ideally, the page will refresh, seek the new URL stub in Context, and display the course's new information.
   */
   useEffect(() => {
-    console.log(selectedCourse)
     if (editCourseDetails === null) {
       setEditCourseDetails(selectedCourse)
     }
@@ -92,7 +91,7 @@ export default function EditCourse({ selectedCourse, editCourseDetails, setEditC
         </p>
         {/* TODO: This button should be disabled if there are >0 materials
           linked to the chapter. */}
-        <DestroyButton action="delete" isFullButton={true} selectedCourse={selectedCourse}>
+        <DestroyButton action="delete" isFullButton={true} selectedCourse={selectedCourse} target="course">
           <DeleteForeverIcon />
         </DestroyButton>
       </Card>

--- a/app/portal/courses/_components/EditMaterial.jsx
+++ b/app/portal/courses/_components/EditMaterial.jsx
@@ -112,7 +112,7 @@ export default function EditMaterial({ material, editMaterialDetails, setEditMat
           Deleting the material will only remove the record entry in this app.
           The source file will NOT be deleted from its cloud storage location.
         </p>
-        <DestroyButton action="delete" isFullButton={true}>
+        <DestroyButton action="delete" isFullButton={true} selectedMaterial={material} target="material">
           <DeleteForeverIcon />
         </DestroyButton>
       </Card>

--- a/components/admin/DestroyButton/DestroyButton.jsx
+++ b/components/admin/DestroyButton/DestroyButton.jsx
@@ -9,16 +9,32 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Typography
 } from "@mui/material"
+import AxiosWithAuth from "@/utils/axiosWithAuth"
+import { useRouter } from "next/navigation"
 
 // TODO: Pass along a function into this component to destroy the object
-const DestroyButton = ({ action, isFullButton, children }) => {
+const DestroyButton = ({ action, isFullButton, children, selectedCourse }) => {
   const [open, setOpen] = React.useState(false)
+  const router = useRouter()
+  const axiosInstance = AxiosWithAuth()
   const handleClickOpen = () => {
     setOpen(true)
   }
   const handleClose = () => {
     setOpen(false)
+  }
+
+  const handleDelete = () => {
+    axiosInstance.delete(`${process.env.NEXT_PUBLIC_BE_API_URL}/courses/delete/${selectedCourse.id}`)
+    .then((res) => {
+      console.log(res)
+      router.push("/portal/courses")
+    })
+    .catch((err) => {
+      console.log(err)
+    })
   }
 
   return (
@@ -51,16 +67,28 @@ const DestroyButton = ({ action, isFullButton, children }) => {
           {action + " confirmation"}
         </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-description">
-            Are you sure you want to {action} the entry?
-          </DialogContentText>
+          {
+            selectedCourse && selectedCourse.materialsCount === 0 ?
+            <DialogContentText id="alert-dialog-description">
+              Are you sure you want to {action} the entry?
+            </DialogContentText>
+            :
+            <Typography color="error">Warning: Delete all course materials before deleting a course.</Typography>
+          }
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
           {/* TODO: Trigger the destroy function if the user clicks the continue button */}
-          <Button onClick={handleClose} autoFocus color="error">
-            Continue
-          </Button>
+          {
+            selectedCourse && selectedCourse.materialsCount === 0 ?
+            <Button onClick={handleDelete} autoFocus color="error">
+              Continue
+            </Button>
+            :
+            <Button onClick={handleClose} autoFocus color="error" disabled={true}>
+              Continue
+            </Button>
+          }
         </DialogActions>
       </Dialog>
     </>

--- a/components/admin/DestroyButton/DestroyButton.jsx
+++ b/components/admin/DestroyButton/DestroyButton.jsx
@@ -15,7 +15,7 @@ import AxiosWithAuth from "@/utils/axiosWithAuth"
 import { useRouter } from "next/navigation"
 
 // TODO: Pass along a function into this component to destroy the object
-const DestroyButton = ({ action, isFullButton, children, selectedCourse }) => {
+const DestroyButton = ({ action, isFullButton, children, selectedCourse, selectedMaterial, target }) => {
   const [open, setOpen] = React.useState(false)
   const router = useRouter()
   const axiosInstance = AxiosWithAuth()
@@ -27,14 +27,25 @@ const DestroyButton = ({ action, isFullButton, children, selectedCourse }) => {
   }
 
   const handleDelete = () => {
-    axiosInstance.delete(`${process.env.NEXT_PUBLIC_BE_API_URL}/courses/delete/${selectedCourse.id}`)
-    .then((res) => {
-      console.log(res)
-      router.push("/portal/courses")
-    })
-    .catch((err) => {
-      console.log(err)
-    })
+
+    if (target === "course") {
+      axiosInstance.delete(`${process.env.NEXT_PUBLIC_BE_API_URL}/courses/delete/${selectedCourse.id}`)
+      .then((res) => {
+        router.push("/portal/courses")
+      })
+      .catch((err) => {
+        console.log(err)
+      })
+    } else if (target === "material") {
+        axiosInstance.delete(`${process.env.NEXT_PUBLIC_BE_API_URL}/courseMaterials/delete/${selectedMaterial.id}`)
+        .then((res) => {
+          // TODO: Keep user on course details page, just remove deleted material from local state list?
+          router.push("/portal/courses")
+        })
+        .catch((err) => {
+          console.log(err)
+        })
+    }
   }
 
   return (
@@ -68,7 +79,7 @@ const DestroyButton = ({ action, isFullButton, children, selectedCourse }) => {
         </DialogTitle>
         <DialogContent>
           {
-            selectedCourse && selectedCourse.materialsCount === 0 ?
+            selectedCourse && selectedCourse.materialsCount === 0 || target === "material" ?
             <DialogContentText id="alert-dialog-description">
               Are you sure you want to {action} the entry?
             </DialogContentText>
@@ -80,7 +91,7 @@ const DestroyButton = ({ action, isFullButton, children, selectedCourse }) => {
           <Button onClick={handleClose}>Cancel</Button>
           {/* TODO: Trigger the destroy function if the user clicks the continue button */}
           {
-            selectedCourse && selectedCourse.materialsCount === 0 ?
+            selectedCourse && selectedCourse.materialsCount === 0 || target === "material" ?
             <Button onClick={handleDelete} autoFocus color="error">
               Continue
             </Button>


### PR DESCRIPTION
This PR introduces the ability to delete courses and course materials, ensuring admins cannot delete courses if a course has materials in the database, requiring them to delete them first.

Changes:

- `DestroyButton` is now aware of a selected course's materials, and presents users with an appropriate message when attempting to delete courses with materials in the database
- `DestroyButton` now receives a `target` variable that tells it what resource is to be deleted based on in which edit modal the button is rendered
- `DestroyButton` now capable of correctly deleting a chosen course or course material