### PR TITLE
feature/chapters-show-members

### DIFF
--- a/app/portal/chapters/[id]/page.js
+++ b/app/portal/chapters/[id]/page.js
@@ -40,8 +40,9 @@ const showEditButton = () => {
 }
 
 const columns = [
-  { field: "memberName", headerName: "Name", width: 250 },
-  { field: "emailAddress", headerName: "Email", width: 300 },
+  { field: "id", headerName: "ID", width: 120 },
+  { field: "name", headerName: "Name", width: 250 },
+  { field: "email", headerName: "Email", width: 300 },
   { field: "adminFlag", headerName: "Admin?", width: 120 },
   {
     field: "edit",
@@ -122,7 +123,7 @@ const ChapterDetailPage = () => {
   const handleOpenCourseLink = () => setOpenCourseLink(true)
   const handleCloseCourseLink = () => setOpenCourseLink(false)
   // Selected Chapter Data
-  const { chapters, course_permissions, setChapters } = useData()
+  const { chapters, course_permissions, setChapters, users } = useData()
   const [selectedChapter, setSelectedChapter] = useState(null)
   const [selectedCourses, setSelectedCourses] = useState(null)
   // Edit Chapter Data
@@ -131,6 +132,8 @@ const ChapterDetailPage = () => {
   const [openMemberNew, setOpenMemberNew] = useState(false)
   const handleOpenMemberNew = () => setOpenMemberNew(true)
   const handleCloseMemberNew = () => setOpenMemberNew(false)
+  // Chapter Members
+  const [members, setMembers] = useState(null)
   // Axios
   const axiosInstance = AxiosWithAuth()
   
@@ -138,6 +141,13 @@ const ChapterDetailPage = () => {
   const regex = /-/g
   const newStr = pathname.slice(17).replace(regex, " ")
 
+  const checkIfNull = (i) => {
+    if (i !== null) {
+      return i
+    }
+  }
+
+  let count = 0
   useEffect(() => {
     if (chapters) {
       chapters.some((obj) => {
@@ -159,14 +169,30 @@ const ChapterDetailPage = () => {
         }
       })
     }
-  })
+    if (users) {
+      const membersList = users.map((i) => {
+        if (selectedChapter && i.chapter_id === selectedChapter.id) {
+          count++
+          let newI = {
+            id: count,
+            name: i.name,
+            email: i.email,
+            adminFlag: i.role_id === 1 || i.role_id === 2 ? true : false,
+            edit: ""
+          }
+          return newI
+        } else {
+          return null
+        }
+      })
+      setMembers(membersList.filter(checkIfNull))
+    }
+  }, [users, selectedChapter])
 
   const handleSubmitEditChapter = () => {
-    console.log(editChapterData)
     axiosInstance
       .post(`${process.env.NEXT_PUBLIC_BE_API_URL}/chapters/update/${editChapterData.id}`, editChapterData)
       .then((res) => {
-        console.log(res)
         let newChapters = chapters.map((i) => {
           if (i.id === res.data.id) {
             return res.data
@@ -174,7 +200,6 @@ const ChapterDetailPage = () => {
             return i
           }
         })
-        console.log(newChapters)
         setChapters(newChapters)
         handleCloseChapterEdit()
         setEditChapterData(null)
@@ -217,22 +242,24 @@ const ChapterDetailPage = () => {
           </IconButton>
         </div>
         <div className="data-grid">
-          <DataGrid
-            rows={rows}
-            columns={columns}
-            initialState={{
-              pagination: {
-                paginationModel: { pageSize: 20 },
-              },
-            }}
-            pageSizeOptions={[20]}
-            slots={{
-              noRowsOverlay: NoRowsOverlay,
-            }}
-            autoHeight={true}
-            sx={{ "--DataGrid-overlayHeight": "300px" }}
-            aria-label="Data grid of chapter members"
-          />
+          {members &&
+            <DataGrid
+              rows={members}
+              columns={columns}
+              initialState={{
+                pagination: {
+                  paginationModel: { pageSize: 20 },
+                },
+              }}
+              pageSizeOptions={[20]}
+              slots={{
+                noRowsOverlay: NoRowsOverlay,
+              }}
+              autoHeight={true}
+              sx={{ "--DataGrid-overlayHeight": "300px" }}
+              aria-label="Data grid of chapter members"
+            />
+          }
         </div>
       </section>
       <section className="container">

--- a/app/portal/chapters/[id]/page.js
+++ b/app/portal/chapters/[id]/page.js
@@ -40,7 +40,6 @@ const showEditButton = () => {
 }
 
 const columns = [
-  { field: "id", headerName: "ID", width: 120 },
   { field: "name", headerName: "Name", width: 250 },
   { field: "email", headerName: "Email", width: 300 },
   { field: "adminFlag", headerName: "Admin?", width: 120 },


### PR DESCRIPTION
This pull requests enables our chapter detail pages to render a list of all users who are a member of the selected chapter.

Note:
I've found that the chapter details page does not work if a chapter name includes a hyphen. This is because of the way I had previously set these pages up to pull the appropriate info for each chapter. The codebase structure with dynamic pages in a Next app limits our ability to use prop drilling, which led me to set up the following steps:

- User selects an item they want to view in detail (Chapter)
- The "Chapters" page pushes them to a dynamic URL for that chapter (`localhost:3000/code-your-dreams`), for example
- The dynamic details page (`chapters/[id]`) reads the unique slug created for the selected chapter
- Taking that slug, it maps over the full list of chapters from context, matching chapter names with the unique URL slug, and sets the `selectedChapter` value to that chapter object

This works in all cases save for chapter names that include hyphens, as in creating the URL slug for each chapter we replace spaces with hyphens, then on the other end (In `chapters/[id]` we remove them from the slug and compare the lower case chapter name against each chapter name in our list (Also made lower case during comparison).

In the case of a name with a hyphen, this results in this:

Chapter Name: `BT Labs - Remote`
URL slug: `bt-labs---remote` (Removing hyphens: `bt labs   remote`)
Chapter Name (Lower Case): `bt labs- remote`

This results in our dynamic page being unable to match against our chapter list and render the proper data.

Going to look into cleaning this up, along with the issue of modals opening for each course material concurrently, next. 💪 