### PR TITLE
patch/bug-cleanup-2

### DIFF
--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -13,7 +13,6 @@ import Modal from "@/components/Modal/Modal"
 import EditCourse from "../_components/EditCourse"
 import NewMaterial from "../_components/NewMaterial"
 import EditMaterial from "../_components/EditMaterial"
-import EditButton from "@/components/admin/EditButton/EditButton"
 import styles from "./page.module.scss"
 import { usePathname, useRouter } from "next/navigation"
 import { useData } from "@/context/appContext"
@@ -92,19 +91,18 @@ export default function Page() {
   }
 
   const showEditButton = (material) => {
+    // Should return a button that simply adds row data to form state and sets the modal to "open"
     return (
-      <EditButton
-        title="Edit Material"
-        handleSubmit={handleSubmitEditMaterial}
-        open={openEditMaterial}
-        setOpen={setOpenEditMaterial}
+      <IconButton
+        color="primary"
+        onClick={() => {
+          setEditMaterialDetails(material)
+          setOpenEditMaterial(true)
+        }}
+        aria-label="Edit button"
       >
-        <EditMaterial
-          material={material}
-          editMaterialDetails={editMaterialDetails}
-          setEditMaterialDetails={setEditMaterialDetails}
-        />
-      </EditButton>
+        {<EditIcon />}
+      </IconButton>
     )
   }
 
@@ -378,6 +376,17 @@ export default function Page() {
         handleSubmit={handleSubmitForm}
       >
         <NewMaterial formState={formState} setFormState={setFormState} />
+      </Modal>
+      <Modal
+        title="Edit Material"
+        handleSubmit={handleSubmitEditMaterial}
+        open={openEditMaterial}
+        handleClose={() => {setOpenEditMaterial(false)}}
+      >
+        <EditMaterial
+          editMaterialDetails={editMaterialDetails}
+          setEditMaterialDetails={setEditMaterialDetails}
+        />
       </Modal>
     </main>
   )

--- a/app/portal/courses/[id]/page.js
+++ b/app/portal/courses/[id]/page.js
@@ -91,7 +91,6 @@ export default function Page() {
   }
 
   const showEditButton = (material) => {
-    // Should return a button that simply adds row data to form state and sets the modal to "open"
     return (
       <IconButton
         color="primary"


### PR DESCRIPTION
This pull request repairs our ability to open edit modals for course materials, fixing an issue where a user trying to open a modal to edit any course material causes modals to open for all found course materials in local state at the same time, blacking out the view of the page and limiting the user to only editing the last material in the list.

We do this by simplifying the button being rendered in each row on `/portal/courses` to run an anonymous function on click that simply tells the modal to open, and sets the `editMaterialDetails` value to the properties of the chosen course material. 

The modal itself is shifted to the bottom of the component, along with the other modals relevant to this page, changing `EditButton` to one of our custom `Modal` components, its `handleClose` function adjusted to match the expected behavior for said modals.