### PR TITLE
fixed edit buttons for tables on admin page

### DIFF
--- a/app/portal/admin/page.js
+++ b/app/portal/admin/page.js
@@ -14,13 +14,13 @@ import {
   TableRow,
 } from "@mui/material"
 import AddIcon from "@mui/icons-material/Add"
+import EditIcon from "@mui/icons-material/Edit"
 import PersonAddIcon from "@mui/icons-material/PersonAdd"
 import Modal from "@/components/Modal/Modal"
 import NewSuperAdmin from "./_components/NewSuperAdmin"
 import NewMaterialType from "./_components/NewMaterialType"
 import EditSuperAdmin from "./_components/EditSuperAdmin"
 import EditMaterialType from "./_components/EditMaterialType"
-import EditButton from "@/components/admin/EditButton/EditButton"
 import useCheckTokenExpired from "@/utils/useCheckTokenExpired"
 import isSuperAdmin from "@/components/admin/isRole/isSuperAdmin"
 
@@ -62,14 +62,15 @@ const AdminPage = () => {
 
   const showSuperAdminEditButton = () => {
     return (
-      <EditButton
-        title="Edit Super Admin"
-        handleSubmit={handleSubmitEditSuperAdmin}
-        open={openSuperAdminEdit}
-        setOpen={setOpenSuperAdminEdit}
+      <IconButton
+        color="primary"
+        onClick={() => {
+          setOpenSuperAdminEdit(true)
+        }}
+        aria-label="Edit button"
       >
-        <EditSuperAdmin />
-      </EditButton>
+        {<EditIcon />}
+      </IconButton>
     )
   }
 
@@ -126,15 +127,15 @@ const AdminPage = () => {
                     <TableCell>{row.material_type}</TableCell>
                     <TableCell align="center">{row.quantity}</TableCell>
                     <TableCell align="center">
-                      {/* TODO: Fix this function so it only opens up a single modal for the row selected */}
-                      <EditButton
-                        title="Edit Material"
-                        handleSubmit={handleSubmitEditMaterials}
-                        open={openMaterialEdit}
-                        setOpen={setOpenMaterialEdit}
+                      <IconButton
+                        color="primary"
+                        onClick={() => {
+                          setOpenMaterialEdit(true)
+                        }}
+                        aria-label="Edit button"
                       >
-                        <EditMaterialType />
-                      </EditButton>
+                        {<EditIcon />}
+                      </IconButton>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -215,11 +216,31 @@ const AdminPage = () => {
         <NewSuperAdmin />
       </Modal>
       <Modal
+        title="Edit Super Admin"
+        handleSubmit={handleSubmitEditSuperAdmin}
+        open={openSuperAdminEdit}
+        handleClose={() => {
+          setOpenSuperAdminEdit(false)
+        }}
+      >
+        <EditSuperAdmin />
+      </Modal>
+      <Modal
         title="Create a New Materials Type"
         open={openMaterialNew}
         handleClose={handleCloseMaterialNew}
       >
         <NewMaterialType />
+      </Modal>
+      <Modal
+        title="Edit Material Type"
+        handleSubmit={handleSubmitEditMaterials}
+        open={openMaterialEdit}
+        handleClose={() => {
+          setOpenMaterialEdit(false)
+        }}
+      >
+        <EditMaterialType />
       </Modal>
     </main>
   )

--- a/app/portal/members/page.js
+++ b/app/portal/members/page.js
@@ -2,12 +2,12 @@
 
 import React, { useState, useEffect } from "react"
 import { IconButton } from "@mui/material"
+import EditIcon from "@mui/icons-material/Edit"
 import PersonAddIcon from "@mui/icons-material/PersonAdd"
 import { DataGrid } from "@mui/x-data-grid"
 import NoRowsOverlay from "@/components/NoRowsOverlay/NoRowsOverlay"
 import Modal from "@/components/Modal/Modal"
 import NewMember from "./_components/NewMember"
-import EditButton from "@/components/admin/EditButton/EditButton"
 import EditMember from "./_components/EditMember"
 import { useData } from "@/context/appContext"
 import useCheckTokenExpired from "@/utils/useCheckTokenExpired"
@@ -15,9 +15,16 @@ import isAdmin from "@/components/admin/isRole/isAdmin"
 
 const MembersPage = () => {
   const [members, setMembers] = useState(null)
-  const [open, setOpen] = useState(false)
-  const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  const [openNewMember, setOpenNewMember] = useState(false)
+  const handleOpenNewMember = () => setOpenNewMember(true)
+  const handleCloseNewMember = () => setOpenNewMember(false)
+  const [openEditMember, setOpenEditMember] = useState(false)
+  const handleCloseEditMember = () => setOpenEditMember(false)
+
+  const handleSubmitNewMember = () => {
+    // TODO: Complete the new processing here
+    console.log("handleSubmitNewMember")
+  }
 
   const handleSubmitEditMember = () => {
     // TODO: Complete the edit processing here
@@ -26,14 +33,15 @@ const MembersPage = () => {
 
   const showEditButton = () => {
     return (
-      <EditButton
-        title="Edit Member"
-        handleSubmit={handleSubmitEditMember}
-        open={open}
-        setOpen={setOpen}
+      <IconButton
+        color="primary"
+        onClick={() => {
+          setOpenEditMember(true)
+        }}
+        aria-label="Edit button"
       >
-        <EditMember />
-      </EditButton>
+        {<EditIcon />}
+      </IconButton>
     )
   }
 
@@ -113,7 +121,7 @@ const MembersPage = () => {
             <IconButton
               color="primary"
               size="large"
-              onClick={() => handleOpen()}
+              onClick={() => handleOpenNewMember()}
               aria-label="Add a new member"
             >
               <PersonAddIcon fontSize="inherit" />
@@ -147,11 +155,19 @@ const MembersPage = () => {
 
       <Modal
         title="Add a New Member"
-        open={open}
-        handleClose={handleClose}
-        handleSubmit={handleSubmitEditMember}
+        open={openNewMember}
+        handleClose={handleCloseNewMember}
+        handleSubmit={handleSubmitNewMember}
       >
         <NewMember />
+      </Modal>
+      <Modal
+        title="Edit Member"
+        open={openEditMember}
+        handleClose={handleCloseEditMember}
+        handleSubmit={handleSubmitEditMember}
+      >
+        <EditMember />
       </Modal>
     </main>
   )


### PR DESCRIPTION
Edit buttons now use the updated modal feature and open only one modal at a time. This fix is implemented for Members and Admin (users and material edit modals) pages.