### PR TITLE
added parameter for header logo

### DIFF
--- a/components/layout/SiteLogo/SiteLogo.jsx
+++ b/components/layout/SiteLogo/SiteLogo.jsx
@@ -13,6 +13,7 @@ export default function SiteLogo() {
         alt="Code Your Dreams logo"
         width={105}
         height={60}
+        priority={true}
       />
     </Link>
   )


### PR DESCRIPTION
Added `priority={true}` to the header site icon to stop Next.js warnings in the logs.